### PR TITLE
Change charttimes to every 3 hrs

### DIFF
--- a/variables_preprocessing.py
+++ b/variables_preprocessing.py
@@ -13,6 +13,28 @@ vitals_df = vitals_df.replace({ICUID: icu2hadm})
 vitals_df.rename(columns={ICUID:HID}, inplace=True)
 vitals_df['charttime'] = vitals_df['charttime'].str.replace('\S{6}$', ':00:00', regex=True)
 vitals_df['charttime'] = pd.to_datetime(vitals_df['charttime'], format='%Y-%m-%d %H:%M:%S')
+# convert all datetime to every 3 hrs
+def convertToInterval(date_obj):
+  hr = date_obj.hour
+  rem = hr%3
+  if rem != 0:
+    new_hour = min(hr+3-rem, 23)
+    date_obj = date_obj.replace(hour=new_hour)
+  return date_obj
+vitals_df['charttime'] = vitals_df['charttime'].apply(convertToInterval)
+# aggregate rows w/ same id and charttime by mean
+grouped_vitals = vitals_df.groupby(['hadm_id', 'charttime']).agg(dict(zip(vitals_df.columns[2:], ['mean']*len(vitals_df.columns))))
+grouped_vitals = grouped_vitals.reset_index()
+# if all values are null use mean of first 30
+all_vitals = pd.DataFrame({}, columns=vitals_df.columns) # empty df to store final values
+hadm_ids = set(grouped_vitals['hadm_id'])
+for hadm_id in hadm_ids:
+  patient = grouped_vitals[grouped_vitals['hadm_id'] == hadm_id]
+  patient = patient.sort_values(by=['charttime'])
+  means = patient.iloc[:32, 2:].mean(axis=0)
+  for col in patient.columns[2:]:
+    patient[col] = patient[col].fillna(means[col])
+  all_vitals = pd.concat([all_vitals, patient])
 vitals_df.to_csv('./data/processed_pivoted_vitals.csv', index=False)
 del vitals_df
 vitals_df = None


### PR DESCRIPTION
- Each time step is 3 hrs w/ 00:00 as the first hour, 03:00 has the next hour
- charttimes within an interval of 3 hrs are aggregated by mean
- any values corresponding to null are filled in by the mean value for the first 30 hours